### PR TITLE
Add support for UuidInterface

### DIFF
--- a/src/UuidDenormalizer.php
+++ b/src/UuidDenormalizer.php
@@ -3,11 +3,12 @@
 namespace GBProd\UuidNormalizer;
 
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 /**
  * Normalizer for Uuid
- * 
+ *
  * @author gbprod <contact@gb-prod.fr>
  */
 class UuidDenormalizer implements DenormalizerInterface
@@ -29,7 +30,7 @@ class UuidDenormalizer implements DenormalizerInterface
      */
     public function supportsDenormalization($data, $type, $format = null)
     {
-        return Uuid::class === $type 
+        return (Uuid::class === $type || UuidInterface::class === $type)
             && $this->isValid($data)
         ;
     }

--- a/src/UuidNormalizer.php
+++ b/src/UuidNormalizer.php
@@ -2,12 +2,12 @@
 
 namespace GBProd\UuidNormalizer;
 
-use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
  * Normalizer for Uuid
- * 
+ *
  * @author gbprod <contact@gb-prod.fr>
  */
 class UuidNormalizer implements NormalizerInterface
@@ -25,6 +25,6 @@ class UuidNormalizer implements NormalizerInterface
      */
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof Uuid;
+        return $data instanceof UuidInterface;
     }
 }

--- a/tests/UuidDenormalizerTest.php
+++ b/tests/UuidDenormalizerTest.php
@@ -5,6 +5,7 @@ namespace Tests\GBProd\UuidNormalizer;
 use GBProd\UuidNormalizer\UuidDenormalizer;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * Tests for UuidDenormalizer
@@ -48,6 +49,16 @@ class UuidDenormalizerTest extends TestCase
             $this->denormalizer->supportsDenormalization(
                 self::UUID_SAMPLE,
                 Uuid::class
+            )
+        );
+    }
+
+    public function testSupportsIsTrueIfTypeIsUuidInterface()
+    {
+        $this->assertTrue(
+            $this->denormalizer->supportsDenormalization(
+                self::UUID_SAMPLE,
+                UuidInterface::class
             )
         );
     }


### PR DESCRIPTION
Adds support for `Ramsey\Uuid\UuidInterface`, in those cases one wants to use the interface instead.