### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
         }
     },
     "require": {
-        "php": "^5.6|^7.0",
-        "ramsey/uuid": "^3.0",
-        "symfony/serializer": "^2.3|^3.0|^4.0"
+        "php": "^5.6|^7.0|^8.0",
+        "ramsey/uuid": "^3.0|^4.0",
+        "symfony/serializer": "^2.3|^3.0|^4.0|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7|^6.0"


### PR DESCRIPTION
This package is compatible with new version of all its dependencies.

So I updated them all.

Fix #9 

_Quick notice: even though it will work with PHP 8, the test suite will fail on PHP8 because phpunit is 6 is not compatible with PHP8. And probably only phpunit 10 will be._