### PR TITLE
Fix supports denormalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file based on the [Keep a Changelog](http://keepachangelog.com/) Standard.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased](https://github.com/gbprod/uuid-normalizer/compare/v1.3.0...HEAD)
+
+- Fix bug in supporting denormalization of classes implementing `UuidInterface` (#35)
+
 ## [v1.3.0](https://github.com/gbprod/uuid-normalizer/compare/v1.2.2...v1.3.0)
 
 - Drop php `<7.4` and Symfony `<=5.4`

--- a/src/UuidDenormalizer.php
+++ b/src/UuidDenormalizer.php
@@ -37,7 +37,7 @@ class UuidDenormalizer implements DenormalizerInterface
      */
     public function supportsDenormalization($data, string $type, string $format = null, array $context = []): bool
     {
-        return Uuid::class === $type || UuidInterface::class === $type;
+        return is_a($type, UuidInterface::class, true);
     }
 
     /**

--- a/tests/UuidDenormalizerTest.php
+++ b/tests/UuidDenormalizerTest.php
@@ -6,6 +6,7 @@ namespace Tests\GBProd\UuidNormalizer;
 
 use GBProd\UuidNormalizer\UuidDenormalizer;
 use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Rfc4122\UuidV1;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
@@ -91,6 +92,16 @@ class UuidDenormalizerTest extends TestCase
     {
         $this->assertNull(
             $this->denormalizer->denormalize(null, Uuid::class)
+        );
+    }
+
+    public function testSupportsIsTrueIfTypeImplementsUuidInterface(): void
+    {
+        $this->assertTrue(
+            $this->denormalizer->supportsDenormalization(
+                self::UUID_SAMPLE,
+                UuidV1::class
+            )
         );
     }
 }


### PR DESCRIPTION
For #36 

This normalizer can serialize anything that implements `UuidInterface`.  However, it could only deserialize `Uuid` or `UuidInterface` — not anything else implementing `UuidInterface`